### PR TITLE
Add CSCS documentation + RCP docker guide

### DIFF
--- a/docs/clusters/cscs.md
+++ b/docs/clusters/cscs.md
@@ -1,1 +1,337 @@
 # Connecting to CSCS
+
+## Pre-setup (access to the CSCS)
+
+Please ask Michael or Annie to add you to the CSCS project. Once you have been added, check your mail for the invitation link. You will to have to create an account.
+
+## Connect to the login node
+
+To connect to the login node, you will need to refresh your key every 24 hours. To refresh your keys, you need to execute the following script. Make sure to replace `$CSCS_USERNAME` with your CSCS username and the `$CSCS_PASSWORD` with your CSCS password. 
+
+```
+#!/bin/bash
+
+# This script sets the environment properly so that a user can access CSCS
+# login nodes via ssh. 
+
+#    Copyright (C) 2023, ETH Zuerich, Switzerland
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, version 3 of the License.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#    AUTHORS Massimo Benini
+
+
+USERNAME=$CSCS_USERNAME
+PASSWORD=$CSCS_PASSWORD
+#read -p "Username : " USERNAME
+#read -s -p "Password: " PASSWORD
+
+function ProgressBar {
+# Process data
+    let _progress=(${1}*100/${2}*100)/100
+    let _done=(${_progress}*4)/10
+    let _left=40-$_done
+# Build progressbar string lengths
+    _fill=$(printf "%${_done}s")
+    _empty=$(printf "%${_left}s")
+
+# 1.2 Build progressbar strings and print the ProgressBar line
+# 1.2.1 Output example:
+# 1.2.1.1 Progress : [########################################] 100%
+printf "\rSetting the environment : [${_fill// /#}${_empty// /-}] ${_progress}%%"
+}
+
+#Variables
+_start=1
+#This accounts as the "totalState" variable for the ProgressBar function
+_end=100
+
+#Params
+MFA_KEYS_URL="https://sshservice.cscs.ch/api/v1/auth/ssh-keys/signed-key"
+
+#Detect OS
+OS="$(uname)"
+case "${OS}" in
+  'Linux')
+    OS='Linux'
+    ;;
+  'FreeBSD')
+    OS='FreeBSD'
+    ;;
+  'WindowsNT')
+    OS='Windows'
+    ;;
+  'Darwin')
+    OS='Mac'
+    ;;
+  *) ;;
+esac
+
+#OS validation
+if [ "${OS}" != "Mac" ] && [ "${OS}" != "Linux" ]; then
+  echo "This script works only on Mac-OS or Linux. Abording."
+  exit 1
+fi
+
+#Read Inputs
+echo
+read -s -p "Enter OTP (6-digit code): " OTP
+echo
+
+if [ -z "${PASSWORD}" ]; then
+    echo "Password is empty."
+    exit 1
+fi
+
+if ! [[ "${OTP}" =~ ^[[:digit:]]{6} ]]; then
+    echo "OTP is not valid, OTP must contains only six digits."
+    exit 1
+fi
+
+ProgressBar 25 "${_end}"
+echo "  Authenticating to the SSH key service..."
+
+HEADERS=(-H "Content-Type: application/json" -H "accept: application/json")
+KEYS=$(curl -s -S --ssl-reqd \
+    "${HEADERS[@]}" \
+    -d "{\"username\": \"$USERNAME\", \"password\": \"$PASSWORD\", \"otp\": \"$OTP\"}" \
+    "$MFA_KEYS_URL")
+
+if [ $? != 0 ]; then
+    exit 1
+fi
+
+ProgressBar 50 "${_end}"
+echo "  Retrieving the SSH keys..."
+
+DICT_KEY=$(echo ${KEYS} | cut -d \" -f 2)
+if [ "${DICT_KEY}" == "payload" ]; then
+   MESSAGE=$(echo ${KEYS} | cut -d \" -f 6)
+   ! [ -z "${MESSAGE}" ] && echo "${MESSAGE}"
+   echo "Error fetching the SSH keys. Aborting."
+   exit 1
+fi
+
+PUBLIC=$(echo ${KEYS} | cut -d \" -f 4)
+PRIVATE=$(echo ${KEYS} | cut -d \" -f 8)
+
+#Check if keys are empty:
+if [ -z "${PUBLIC}" ] || [ -z "${PRIVATE}" ]; then
+    echo "Error fetching the SSH keys. Aborting."
+    exit 1
+fi
+
+ProgressBar 75 "${_end}"
+echo "  Setting up the SSH keys into your home folder..."
+
+#Check ~/.ssh folder and store the keys
+echo ${PUBLIC} | awk '{gsub(/\\n/,"\n")}1' > ~/.ssh/cscs-key-cert.pub || exit 1
+echo ${PRIVATE} | awk '{gsub(/\\n/,"\n")}1' > ~/.ssh/cscs-key || exit 1
+
+#Setting permissions:
+chmod 644 ~/.ssh/cscs-key-cert.pub || exit 1
+chmod 600 ~/.ssh/cscs-key || exit 1
+
+#Format the keys:
+if [ "${OS}" = "Mac" ]
+then
+  sed -i '' -e '$ d' ~/.ssh/cscs-key-cert.pub || exit 1
+  sed -i '' -e '$ d' ~/.ssh/cscs-key || exit 1
+else [ "${OS}" = "Linux" ]
+  sed '$d' ~/.ssh/cscs-key-cert.pub || exit 1
+  sed '$d' ~/.ssh/cscs-key || exit 1
+fi
+
+ProgressBar 100 "${_end}"
+echo "  Completed."
+
+exit_code_passphrase=1
+read -n 1 -p "Do you want to add a passphrase to your key? [y/n] (Default y) " reply; 
+if [ "$reply" != "" ];
+ then echo;
+fi
+if [ "$reply" = "${reply#[Nn]}" ]; then
+      while [ $exit_code_passphrase != 0 ]; do
+        ssh-keygen -f ~/.ssh/cscs-key -p
+        exit_code_passphrase=$?
+      done
+fi
+
+if (( $exit_code_passphrase == 0 ));
+  then
+    SUBSTRING=", using the passphrase you have set:";
+  else
+     SUBSTRING=":";
+fi     
+
+eval `ssh-agent -s`
+ssh-add -t 1d ~/.ssh/cscs-key
+```
+
+We strongly suggest to store this script in a file as you will have to execute it every day. If you don't want to have your login ID stored in a script, you can comment out the lines:
+
+```
+#read -p "Username : " USERNAME
+#read -s -p "Password: " PASSWORD
+```
+
+and remove the lines:
+
+```
+USERNAME=$CSCS_USERNAME
+PASSWORD=$CSCS_PASSWORD
+```
+
+## Setup your ssh config
+
+Add the following lines to the `~/.ssh/config` file:
+
+```
+Host ela
+    HostName ela.cscs.ch
+    User $CSCS_USERNAME
+    ForwardAgent yes
+    ForwardX11 yes
+    forwardX11Trusted yes
+	IdentityFile ~/.ssh/cscs-key
+
+
+Host todi
+    HostName todi.cscs.ch
+    User $CSCS_USERNAME
+    ProxyJump ela
+    ForwardAgent yes
+    ForwardX11 yes
+    forwardX11Trusted yes
+	IdentityFile ~/.ssh/cscs-key
+
+Host clariden
+    HostName clariden.cscs.ch
+    User $CSCS_USERNAME
+    ProxyJump ela
+    ForwardAgent yes
+    ForwardX11 yes
+    forwardX11Trusted yes
+    IdentityFile ~/.ssh/cscs-key
+```
+
+To connect to the cluster, run the following:
+
+```
+# Your terminal
+
+ssh clariden
+```
+
+This opens a terminal on the CSCS login node. 
+
+## Setup Github
+
+To operate on private repositories on GitHub. You can either generate a SSH key pairs or use a GitHub personal access token (GitHub PAT). We recommand doing the second option but both options are viable.
+
+To generate a GitHub PAT, follow those [instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic). Make sure that this PAT is stored somewhere
+
+For this tutorial, we are gonna use the `MultiMeditron` training pipeline setup. Clone the MultiMeditron repository in your user directory:
+
+```
+# CSCS login node
+
+mkdir /users/$CSCS_USERNAME/meditron
+cd /users/$CSCS_USERNAME/meditron
+
+git clone https://github.com/OpenMeditron/MultiMeditron.git
+```
+
+When GitHub asks for your password, input the PAT that you have generated in this step.
+
+## Setup the environment on the cluster
+
+> *__IMPORTANT NOTE__:* NEVER RUN ANY COMPUTE JOB ON THE LOGIN NODE (or else you will slow down everyone on the cluster). THE LOGIN NODE SHOULD ONLY BE USED TO SCHEDULE JOB.
+
+The terminal will spawn you into the `/users/$CSCS_USERNAME` directory.
+
+When running job, you will need to execute your job inside docker images. This is done by using `.toml` files that specify which docker image, environment variables are gonne be set when running the job. Create a folder `.edf` in `/users/$CSCS_USERNAME`:
+
+```
+# CSCS login node
+
+mkdir /users/$CSCS_USERNAME/.edf
+```
+
+
+
+Create a `.edf/multimodal.toml` file:
+
+```
+image = "/capstor/store/cscs/swissai/a127/meditron/docker/multimeditron_latest.sqsh"
+mounts = ["/capstor", "/iopsstor", "/users"]
+
+writable = true
+
+workdir = "path/to/MultiMeditron"
+
+[annotations]
+com.hooks.aws_ofi_nccl.enabled = "true"
+com.hooks.aws_ofi_nccl.variant = "cuda12"
+
+[env]
+CUDA_CACHE_DISABLE = "1"
+NCCL_NET = "AWS Libfabric"
+NCCL_CROSS_NIC = "1"
+NCCL_NET_GDR_LEVEL = "PHB"
+FI_CXI_DISABLE_HOST_REGISTER = "1"
+FI_MR_CACHE_MONITOR = "userfaultfd"
+FI_CXI_DEFAULT_CQ_SIZE = "131072"
+FI_CXI_DEFAULT_TX_SIZE = "32768"
+FI_CXI_RX_MATCH_MODE = "software"
+FI_CXI_SAFE_DEVMEM_COPY_THRESHOLD = "16777216"
+FI_CXI_COMPAT = "0"
+```
+
+Notice 2 things:
+
+* We specify the path to the `.sqsh` file in the `image` attribute. This is the image used by the job that stores all of the dependencies.
+* We specify the path to the MultiMeditron repo in the `workdir` attribute. This is the directory where we spawn when the job is launched.
+
+Note that for other types of job, you will probably require a different image and a different working directory.
+
+## Launching job
+
+There are 2 types of job that you can launch:
+
+- Interactive using `srun` (which gives you a terminal)
+- Non-interactive using `sbatch` (which schedule a job)
+
+### Interactive job
+
+On the login node, you can launch an interactive job by executing the following command:
+
+```
+srun --time=1:29:59 --partition debug -A a127 --environment=/users/$CSCS_USERNAME/.edf/multimodal.toml --pty bash
+```
+
+Here is a breakdown of the command:
+
+- `--time` is the maximum running time of the job (here, the job runs for 1h30 before it gets killed)
+- `--partition debug` is the node partition in which the job executed. As of 14/08/2025, there are 3 partitions:
+
+    - `normal`: with a maximum running time of 12 hours and no limit on the number of distributed nodes. This partition is the partition used for non-interactive jobs and long interactive jobs
+    - `debug`: with a maximum running time of 1h30 with only one node. This partition is meant for interactive jobs
+    - `xfer`: this partition is meant for data transfer and doesn't claim any GPU
+
+
+
+
+### Non-interactive job
+
+On 

--- a/docs/clusters/cscs_docker.md
+++ b/docs/clusters/cscs_docker.md
@@ -1,0 +1,116 @@
+# Building images for the CSCS
+
+This tutorial assumes that you followed the CSCS setup tutorial at [cscs.md](cscs.md)
+
+## Claim a job to build docker image
+
+Connect to the CSCS login node:
+
+```bash
+ssh clariden
+```
+
+Claim a job:
+
+```bash
+# On the login node
+
+srun --time 11:59:59 -p normal -A a127 --pty bash
+```
+
+Make sure to put a big timeout as building docker images can take a lot of time
+
+## Building the image
+
+Create your Dockerfile and name it `Dockerfile`. For example, this is the Dockerfile used to run axolotl:
+
+```dockerfile
+FROM nvcr.io/nvidia/pytorch:24.07-py3
+
+# setup
+RUN apt-get update && apt-get install python3-pip python3-venv -y
+RUN pip install --upgrade pip setuptools
+
+# Axolotl installs
+RUN MAX_JOBS=24 pip install flash-attn==2.6.2 --no-build-isolation
+RUN pip install trl==0.9.6
+RUN pip install fschat@git+https://github.com/lm-sys/FastChat.git@27a05b04a35510afb1d767ae7e5990cbd278f8fe
+RUN pip install deepspeed==0.14.4
+
+RUN MAX_JOBS=8 TORCH_CUDA_ARCH_LIST="9.0" pip install -v -U git+https://github.com/facebookresearch/xformers.git@main#egg=xformers
+RUN pip install transformers@git+https://github.com/huggingface/transformers.git@026a173a64372e9602a16523b8fae9de4b0ff428
+
+COPY axolotl/ /workspace/axolotl
+WORKDIR /workspace/axolotl
+RUN pip install -e .
+```
+
+Note that this Dockerfile assumes that you have the [axolotl repository](https://github.com/axolotl-ai-cloud/axolotl) cloned in `path/to/root_directory`
+
+Run:
+
+```bash
+# Recommended: change the tag from my_awesome_image to a more meaningful one
+
+podman build -f /path/to/root_directory/Dockerfile -t my_awesome_image path/to/root_directory
+```
+
+You can change the base docker image (the `FROM` value) to have a more recent version of the CUDA driver. You can check the available tags [here](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch/tags).
+
+**IMPORTANT NOTE:** Note that the CSCS cluster uses an ARM64 architecture. Make sure that you are building your packages for this architecture. Some libraries like VLLM may be trickier to install as they rely on low-level optimization.
+
+## Export the docker image to a .sqsh file
+
+Run the following command, you can change the `my_custom_image.sqsh` file name to a more meaningful one.
+
+```bash
+enroot import -o /capstor/store/cscs/swissai/a127/meditron/docker/my_custom_image.sqsh podman://localhost/my_awesome_image:latest
+```
+
+Set the correct permissions:
+
+```bash
+setfacl -b /capstor/store/cscs/swissai/a127/meditron/docker/my_custom_image.sqsh
+chmod +r /capstor/store/cscs/swissai/a127/meditron/docker/my_custom_image.sqsh
+```
+
+## Use your new Docker image
+
+To use your new Docker image, create a new toml file in `$HOME/.edf` (in this example we name it `example.toml`):
+
+```
+image = "/capstor/store/cscs/swissai/a127/meditron/docker/my_custom_image.sqsh"
+mounts = ["/capstor", "/iopsstor", "/users"]
+
+writable = true
+
+# Uncomment this to set a particular working directory
+# workdir = "/path/to/workdir"
+
+[annotations]
+com.hooks.aws_ofi_nccl.enabled = "true"
+com.hooks.aws_ofi_nccl.variant = "cuda12"
+
+[env]
+CUDA_CACHE_DISABLE = "1"
+NCCL_NET = "AWS Libfabric"
+NCCL_CROSS_NIC = "1"
+NCCL_NET_GDR_LEVEL = "PHB"
+FI_CXI_DISABLE_HOST_REGISTER = "1"
+FI_MR_CACHE_MONITOR = "userfaultfd"
+FI_CXI_DEFAULT_CQ_SIZE = "131072"
+FI_CXI_DEFAULT_TX_SIZE = "32768"
+FI_CXI_RX_MATCH_MODE = "software"
+FI_CXI_SAFE_DEVMEM_COPY_THRESHOLD = "16777216"
+FI_CXI_COMPAT = "0"
+```
+
+Note the line starting with `image =`
+
+Then, to claim an interactive job with this image:
+
+```
+srun --time=1:29:59 --partition debug -A a127 --environment=$HOME/.edf/example.toml --pty bash
+```
+
+For non interactive job. Look for the `--environment` argument in the srun arguments and change it to your desired `.toml` file (here `example.toml`

--- a/docs/clusters/rcp.md
+++ b/docs/clusters/rcp.md
@@ -162,7 +162,7 @@ runai submit \
 Explanation:
 
 * `name` is the name of the job
-* `image` is the link to the docker image that will be attached to the cluster
+* `image` is the link to the docker image that will be attached to the cluster. **Please note that you may need to change the image path if you pushed your image on another link. See [Building Docker image for the RCP](rcp_docker.md)**
 * `pvc` determines which scratch will be mounted to the job. The argument is of the form: `name_of_the_scratch:/mount/path/to/scratch`. Here the we are mounting the scratch named `light-scratch` to the local path `/mloscratch` **This is part may cause an error because of the LIGHT migration** 
 * `gpu` is the number of GPU that you want to claim for this job (larger amount of GPU will be harder to get as ressources are limited)
 

--- a/docs/clusters/rcp_docker.md
+++ b/docs/clusters/rcp_docker.md
@@ -1,0 +1,169 @@
+# Building Docker image for the RCP
+
+
+To build a Docker image for the RCP, we will use the [LiGHT cluster template](https://github.com/EPFLiGHT/LiGHT-cluster-template).
+
+Prerequisites:
+- You need [docker](https://www.docker.com/) on your computer
+- A Linux environment (as we are building docker images that target Linux)
+- Good specs, building docker images require lots of resources in RAM and can take lots of space in your disk. Make sure that your computer is "good enough"
+
+## Setup
+
+On your machine:
+
+```
+git clone https://github.com/EPFLiGHT/LiGHT-cluster-template.git
+```
+
+The repository contains tutorials and reproducibility scripts for many clusters, but we will only focus on the RCP in thus tutorial.
+
+```
+cd LiGHT-cluster-template/installation/docker-amd64-cuda
+```
+
+We will build the docker images in the following way:
+
+1. Build a generic docker image that contains all the dependencies (NVidia drivers, pip, uv, git, etc.)
+2. Build many user docker images extending this generic image with the right permisions
+
+This folder contains a `template.sh` file which contains all the available functions
+
+### Creating a project on the EPFL registry (Optional)
+
+EPFL has a registry of docker images which works in a similar way to the Docker hub. This registry is used to store docker images and is only accessible through the [EPFL VPN](https://www.epfl.ch/campus/services/ressources-informatiques/network-services-reseau/acces-intranet-a-distance/clients-vpn-disponibles/).
+
+Connect to registry.rcp.epfl.ch with the VPN. To push new docker images, you need to create a Project. At the time of this tutorial, some projects have already been created like [multimeditron](https://registry.rcp.epfl.ch/harbor/projects/316/members/summary) and you can ask Michael to add you to the project so that you can also push Docker images to this project.
+
+You also have the possibility of creating your own project by clicking on "New project". 
+
+__IMPORTANT__: Beware that if you choose to create your own project, you will have to change the link of the docker images in the scripts accordingly (mainly replacing multimeditron/basic by the right path)
+
+### Generating the .env file
+
+Run the following command:
+
+```
+./template.sh env
+```
+
+This command create a (hidden) `.env` file which looks like this:
+
+```
+# All user-specific configurations are here.
+
+## For building:
+# Which docker and compose binary to use
+# docker and docker compose in general or podman and podman-compose for CSCS Clariden
+DOCKER=docker
+COMPOSE="docker compose"
+# Use the same USRID and GRPID as on the storage you will be mounting.
+# USR is used in the image name and must be lowercase.
+# It's fine if your username is not lowercase, jut make it lowercase.
+USR=john
+USRID=1000
+GRPID=984
+GRP=users
+# PASSWD is not secret,
+# it is only there to avoid running password-less sudo commands accidentally.
+PASSWD=john
+# LAB_NAME will be the first component in the image path.
+# It must be lowercase.
+LAB_NAME=users
+
+#### For running locally
+# You can find the acceleration options in the compose.yaml file
+# by looking at the services with names dev-local-ACCELERATION.
+PROJECT_ROOT_AT=/path/to/LiGHT-cluster-template
+ACCELERATION=cuda
+WANDB_API_KEY=
+# PyCharm-related. Fill after installing the IDE manually the first time.
+PYCHARM_IDE_AT=
+
+
+####################
+# Project-specific environment variables.
+## Used to avoid writing paths multiple times and creating inconsistencies.
+## You should not need to change anything below this line.
+PROJECT_NAME=template-project-name
+PACKAGE_NAME=template_package_name
+IMAGE_NAME=${LAB_NAME}/${USR}/${PROJECT_NAME}
+IMAGE_PLATFORM=amd64-cuda
+# The image name includes the USR to separate the images in an image registry.
+# Its tag includes the platform for registries that don't hand multi-platform images for the same tag.
+# You can also add a suffix to the platform e.g. -jax or -pytorch if you use different images for different environments/models etc.
+```
+
+Edit this file by setting `LAB_NAME` to the name of the project you have given in the previous step (multimeditron if you choose to push your docker images there).
+Set the `PROJECT_NAME` to a meaningful name to group the docker images that belong to the same project. Here we will choose to set it up to `basic`. Docker images with the same `PROJECT_NAME` will appear together in the `registry.rcp.epfl.ch` interface.
+
+We also change the `IMAGE_NAME` to another template for organization purpose.
+
+Edit the corresponding lines to the following lines:
+
+```
+LAB_NAME=multimeditron # Or the name you have chosen
+PROJECT_NAME=basic # Optional: Change this to a more meaningful name (e.g. vllm or axolotl for instance)
+IMAGE_NAME=${LAB_NAME}/${PROJECT_NAME}
+```
+
+### Building the generic docker image
+
+Beware that this docker image uses the `Dockerfile` to build. You may need to change the base Docker image in `compose-base.yaml`:
+
+```
+BASE_IMAGE: nvcr.io/nvidia/pytorch:pytorch:24-07-py3 # (Optional: Change this tag to a newer version)
+```
+
+You can change this line to another newer version that you can find [here](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch/tags). This will change the version of the NVidia driver that many libraries rely on. Some of the latest features may only be compatible with the newer version of the drivers (for instance the flash-attn library).
+
+To build the generic docker image run the following command:
+
+```
+./template.sh build_generic
+```
+
+Useful commands:
+
+`docker ps`: To list all the docker images on your machine. Search for the one that you just built, it should have the name that you set up in `IMAGE_NAME`. So if we are using multimeditron, it will be tagged as `multimeditron/basic:amd64-cuda-root-latest` and `multimeditron/basic:amd64-cuda-root-<some git commit hash>`
+
+`docker run --rm -it --entrypoint bash multimeditron/basic:amd64-cuda-root-latest`: To bash into your new docker image and test if you have everything installed correctly.
+
+### Building the user docker images
+
+Connect to people.epfl.ch and search for the user you want to build an image. You need the `Username` and the `UID` fields to build the user docker image
+
+Connect to groups.epfl.ch and search for light-scratch in "All groups". You need the `GID` field.
+
+To build user docker images, you need to edit the `.env` file. You need to change the following attributes:
+
+```
+GRPID=<GID of the light-scratch>
+
+USRID=<UID of the user>
+USR=<Username of the user>
+PASSWD=<Username of the user>
+```
+
+
+To build the user docker image, run:
+
+```
+./template.sh build_user
+```
+
+### Push the docker images
+
+Login to the registry:
+
+```
+docker login
+```
+
+The login informations are your EPFL login
+
+```
+./template.sh push_generic RCP
+./template.sh push_user RCP
+```
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,10 +15,14 @@ nav:
   - Home: index.md
   - Getting started: gettingstarted.md
   - Projects: projects.md
-  - Connecting to clusters: 
+  - Clusters documentation: 
     - Overview: clusters.md
-    - RCP: clusters/rcp.md
-    - CSCS: clusters/cscs.md
+    - RCP: 
+      - Connecting to the RCP: clusters/rcp.md
+      - Building Docker image for the RCP: clusters/rcp_docker.md
+    - CSCS: 
+      - Connecting to the CSCS: clusters/cscs.md
+      - Building image for the CSCS: clusters/cscs_docker.md
   - Contributing: contributing.md
   - About: about.md
 


### PR DESCRIPTION
This pull request adds comprehensive documentation for building Docker images on both the RCP and CSCS clusters, and updates the navigation structure to make these guides more accessible. It also clarifies instructions in the RCP cluster documentation regarding Docker image paths.

**Documentation additions and improvements:**

* Added a detailed tutorial for building Docker images on the CSCS cluster, including job claiming, Dockerfile setup, building images with `podman`, exporting to `.sqsh`, and using the image with `.toml` configuration files.
* Added a step-by-step guide for building and pushing Docker images for the RCP cluster using the LiGHT cluster template, including environment setup, `.env` configuration, building generic and user images, and pushing to the EPFL registry.
* Updated the RCP cluster documentation to clarify that users may need to adjust the Docker image path depending on where the image is pushed, and referenced the new RCP Docker image building guide.

**Navigation updates:**

* Updated the navigation in `mkdocs.yml` to group cluster documentation under "Clusters documentation", and added links to the new Docker image building guides for both RCP and CSCS.